### PR TITLE
APA7 Fixing Legislation Italics

### DIFF
--- a/markdown/apa7thed.md
+++ b/markdown/apa7thed.md
@@ -971,11 +971,11 @@ It is necessary to also state the jurisdiction of the legislation, either in the
 
 *Note: Include the jurisdiction the first time the act is cited. The jurisdiction can be dropped with subsequent citations.*
 
-> According to the Victorian Mental Health Act (2014, s. 29) . . .
+> According to the *Victorian Mental Health Act* (2014, s. 29) . . .
 
-> Victoria’s Mental Health Act (2014, s. 29) states that . . .
+> Victoria’s *Mental Health Act* (2014, s. 29) states that . . .
 
-> By virtue of s. 130.1 of the Mental Health Act 2014 (Vic) . . .
+> By virtue of s. 130.1 of the *Mental Health Act 2014* (Vic) . . .
 
 #### Direct quote in-text
 


### PR DESCRIPTION
Act title should be in italics. Edits made to reflect this.